### PR TITLE
hotfix: Fix typo at the NODE_VERSION env.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Angel Adames <a.adames@gbh.com.do>"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PHP_VERSION 7.1
-ENV NODE_VERSION 8.11.4
+ENV NODE_VERSION v8.11.4
 ENV NVM_VERSION 0.33.11
 
 # Install Dependecies


### PR DESCRIPTION
**Problem**

Using the tag `v1.9` it throws `npm not found` when you use any thing related to npm.

**Steps to reproduce**

1- Create a `dockerfile` for your APP and use the tag `v1.9`.
2- Try to do any command that implies `npm`.
3- It should throw `npm not found`.

**Solution**
NVM save the node version using the v character followed by the version number, ex: 10.15.0 it saves with v10.15.0. It only had to change from `8.11.4` to `v8.11.4`.

**Comments**
@b-nicasio @angelmadames It doesn't allow me to point to the tag v1.9, only master :/